### PR TITLE
Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 *Задание:*
 
-Реализуйте функцию exceptionSafeInvoke, которая аналогична std::invoke, но при этом не выпускает из себя исключения, т.е.:
-- Если Callabale возвращает void, то exceptionSafeInvoke() должна возвращать bool (false, если произошло любое исключение).
-- Если Callabale возвращает T != void, то exceptionSafeInvoke() должна возвращать std::optional<T> (nullopt, если произошло любое исключение).
+Реализуйте функцию exceptionSafeInvoke, которая аналогична std::invoke, но при этом не выпускает из себя исключения,
+т.е.:
+
+- Если Callabale возвращает void, то exceptionSafeInvoke() должна возвращать bool (false, если произошло любое
+  исключение).
+- Если Callabale возвращает T != void, то exceptionSafeInvoke() должна возвращать std::optional<T> (nullopt, если
+  произошло любое исключение).
 
 *Реализация:*
 
@@ -19,22 +23,26 @@
 Выполняется вызов функций.
 
 *Сборка:*
-~~~
+
+```bash
 cmake -B build
 cmake --build build
-~~~
+```
 
 *Запуск:*
-~~~
+
+```bash
 ./build/invoke
-~~~
+```
 
 *Запуск тестов:*
-~~~
+
+```bash
 ./build/test/test_run
-~~~
+```
 
 *Интеграционные тесты:*
-~~~
-sh test/integr/test.sh
-~~~
+
+```bash
+bash test/integr/test.sh
+```

--- a/exe/CMakeLists.txt
+++ b/exe/CMakeLists.txt
@@ -8,9 +8,3 @@ add_executable(invoke ${EXE_SOURCES})
 
 target_link_libraries(invoke PRIVATE exceptionSafeInvoke_lib)
 set_target_properties(invoke PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-
-#message(STATUS ${CMAKE_SOURCE_DIR} ${SOME_VAL})
-#message(STATUS ${CMAKE_CURRENT_SOURCE_DIR})
-#target_include_directories(sum_lib PUBLIC ${CMAKE_SOURCE_DIR}/include)
-
-#SET(SOME_VAL2 dfjkdsfjk)

--- a/include/exceptionSafeInvoke.h
+++ b/include/exceptionSafeInvoke.h
@@ -55,7 +55,7 @@ namespace detail {
     bool exceptionSafeInvokeVoid(F&& f, Args&&... args) {
         try {
             std::forward<F>(f)(std::forward<Args>(args)...);
-            return false;
+            return true;
         }
         catch (...) {
             return false;
@@ -68,7 +68,7 @@ namespace detail {
             return std::forward<F>(f)(std::forward<Args>(args)...);
         }
         catch(...) {
-            return NULL;
+            return std::nullopt;
         }
     }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,4 @@
 project(test)
-add_subdirectory(lib)
 include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
 
 add_executable(test_run test.cpp)

--- a/test/integr/test.sh
+++ b/test/integr/test.sh
@@ -8,13 +8,20 @@ path="./build/invoke"
 
 output=$($path 0123)
 if [[ $output == "0" ]]; then
-	echo "OK"
+  echo "OK"
 else
-	echo "FAILED"
+  echo "FAILED"
 fi
 
 output=$($path 123 88)
 if [[ $output == "Usage: ./<program> <some_input>" ]]; then
+  echo "OK"
+else
+  echo "FAILED"
+fi
+
+output=$($path mad)
+if [[ $output == "1" ]]; then
   echo "OK"
 else
   echo "FAILED"

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -75,3 +75,27 @@ TEST(testInvoke, testFieldAccess) {
     Foo foo(2);
     EXPECT_EQ(2, exceptionSafeInvoke(&Foo::num_, foo));
 }
+
+TEST(testInvoke, testFunctionVoid) {
+    EXPECT_TRUE(exceptionSafeInvoke(testFunc, 111));
+    EXPECT_FALSE(exceptionSafeInvoke(testFunc, 0));
+    EXPECT_FALSE(exceptionSafeInvoke([]() { print_num(0); }));
+    EXPECT_TRUE(exceptionSafeInvoke([]() { print_num(11); }));
+}
+
+TEST(testInvoke, testFunctionNonvoid) {
+    EXPECT_EQ(std::nullopt, exceptionSafeInvoke(return_num, 0));
+    EXPECT_EQ(11, exceptionSafeInvoke(return_num, 11).value());
+    EXPECT_EQ(123, exceptionSafeInvoke([]() { return return_num(123); }));
+    EXPECT_EQ(std::nullopt, exceptionSafeInvoke([]() { return return_num(0); }));
+}
+
+TEST(testInvoke, testFunctionObjectVoid) {
+    EXPECT_TRUE(exceptionSafeInvoke(PrintNum(), 18));
+    EXPECT_FALSE(exceptionSafeInvoke(PrintNum(), 0));
+}
+
+TEST(testInvoke, testFunctionObjectNonvoid) {
+    EXPECT_EQ(18, exceptionSafeInvoke(ReturnNum(), 18));
+    EXPECT_EQ(std::nullopt, exceptionSafeInvoke(ReturnNum(), 0));
+}


### PR DESCRIPTION
### Summary
В этом PR следующие исправления:
- исправлены две логические ошибки, допущенные намеренно
- добавлены 4 юнит-теста и 1 интеграционный тест, которые не проходили на сломанном коде
- убрана лишняя строка add_subdirectory в тестовом `CMakeLists.txt`
- приукрашен `README.md` (теперь в CLion его можно прокликивать)
- убран бесполезный комментарий в `exe/CMakeLists.txt`, который был, похоже, еще в методичке